### PR TITLE
First fix of name capture, plus other refactors

### DIFF
--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/ArgSpec.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/ArgSpec.java
@@ -7,7 +7,11 @@ import uk.bs338.hashLisp.jproto.hons.HonsValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 public class ArgSpec {
     private final @NotNull ExprFactory exprFactory;
@@ -77,5 +81,40 @@ public class ArgSpec {
             "argNames=" + argNames.stream().map(heap::valueToString).toList() +
             ", slurpyName=" + heap.valueToString(slurpyName) +
             '}';
+    }
+    
+    public @NotNull Set<HonsValue> getBoundVariables() {
+        Set<HonsValue> names = new HashSet<>(argNames.size() + 1);
+
+        if (slurpyName != null)
+            names.add(slurpyName);
+
+        names.addAll(argNames);
+
+        return names;
+    }
+    
+    public @NotNull Assignments alphaConversion(int uniqNumber) {
+        Map<HonsValue, HonsValue> oldNameToNewName = new HashMap<>(argNames.size() + 1);
+        String prefix = "$%x$".formatted(uniqNumber);
+
+        Consumer<HonsValue> addPrefix = (old) -> {
+            var oldName = heap.symbolName(old);
+            if (heap.fst(oldName).toSmallInt() == '$')
+                return;
+            var newName = heap.symbolName(old);
+            for (int idx = prefix.length() - 1; idx >= 0; idx--) {
+                newName = heap.cons(HonsValue.fromSmallInt(prefix.charAt(idx)), newName);
+            }
+            oldNameToNewName.put(old, heap.makeSymbol(newName));
+        };
+        
+        if (slurpyName != null)
+            addPrefix.accept(slurpyName);
+        
+        for (var name : argNames)
+            addPrefix.accept(name);
+        
+        return new Assignments(exprFactory, oldNameToNewName);
     }
 }

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/ArgSpec.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/ArgSpec.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 public class ArgSpec {
     private final @NotNull ExprFactory exprFactory;
@@ -97,23 +96,20 @@ public class ArgSpec {
     public @NotNull Assignments alphaConversion(int uniqNumber) {
         Map<HonsValue, HonsValue> oldNameToNewName = new HashMap<>(argNames.size() + 1);
         String prefix = "$%x$".formatted(uniqNumber);
-
-        Consumer<HonsValue> addPrefix = (old) -> {
+        
+        var boundVariables = this.getBoundVariables();
+        
+        for (var old : boundVariables) {
             var oldName = heap.symbolName(old);
             if (heap.fst(oldName).toSmallInt() == '$')
-                return;
+                continue;
+            
             var newName = heap.symbolName(old);
             for (int idx = prefix.length() - 1; idx >= 0; idx--) {
                 newName = heap.cons(HonsValue.fromSmallInt(prefix.charAt(idx)), newName);
             }
             oldNameToNewName.put(old, heap.makeSymbol(newName));
-        };
-        
-        if (slurpyName != null)
-            addPrefix.accept(slurpyName);
-        
-        for (var name : argNames)
-            addPrefix.accept(name);
+        }
         
         return new Assignments(exprFactory, oldNameToNewName);
     }

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/Assignments.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/Assignments.java
@@ -11,12 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 class Assignments {
-    private final ExprFactory exprFactory;
-    private final HonsHeap heap;
+    private final @NotNull ExprFactory exprFactory;
+    private final @NotNull HonsHeap heap;
     private @Nullable HonsValue assignmentsAsValue;
-    private final Map<HonsValue, HonsValue> assignments;
+    private final @NotNull Map<HonsValue, HonsValue> assignments;
 
-    public Assignments(ExprFactory exprFactory, Map<HonsValue, HonsValue> assignments) {
+    public Assignments(@NotNull ExprFactory exprFactory, @NotNull Map<HonsValue, HonsValue> assignments) {
         this.exprFactory = exprFactory;
         this.heap = exprFactory.getHeap();
         this.assignmentsAsValue = null;
@@ -46,8 +46,18 @@ class Assignments {
     }
     
     public @NotNull Assignments withoutNames(Collection<HonsValue> names) {
+        if (names.isEmpty())
+            return this;
         var reducedAssignments = new HashMap<>(assignments);
         reducedAssignments.keySet().removeAll(names);
         return new Assignments(exprFactory, reducedAssignments);
+    }
+    
+    public @NotNull Assignments addAssignments(Map<HonsValue, HonsValue> newAssignments) {
+        if (newAssignments.isEmpty())
+            return this;
+        var combined = new HashMap<>(assignments);
+        combined.putAll(newAssignments);
+        return new Assignments(exprFactory, combined);
     }
 }

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/LazyEvaluator.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/LazyEvaluator.java
@@ -69,7 +69,7 @@ public class LazyEvaluator implements IEvaluator<HonsValue> {
     }
 
     public IExpr substitute(@NotNull Assignments assignments, @NotNull IExpr body) {
-        return SubstituteVisitor.substitute(exprFactory, primitives, this, assignments, body);
+        return SubstituteVisitor.substitute(exprFactory, primitives, assignments, body);
     }
 
     /* result needs further evaluation */

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
@@ -7,7 +7,7 @@ import uk.bs338.hashLisp.jproto.hons.HonsValue;
 
 import java.util.Optional;
 
-class SubstituteVisitor implements IExprVisitor2, ISubstitutor<HonsValue> {
+class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
     private final @NotNull ExprFactory exprFactory;
     private final @NotNull Primitives primitives;
     private final @NotNull Assignments assignments;

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
@@ -1,12 +1,12 @@
 package uk.bs338.hashLisp.jproto.eval;
 
 import org.jetbrains.annotations.NotNull;
-import uk.bs338.hashLisp.jproto.IEvaluator;
 import uk.bs338.hashLisp.jproto.eval.expr.*;
 import uk.bs338.hashLisp.jproto.hons.HonsValue;
 
 import java.util.Optional;
 
+/* since this recurses into itself, I suppose we can just reuse result, instead of creating lots of new visitors */
 class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
     private final @NotNull ExprFactory exprFactory;
     private final @NotNull Primitives primitives;
@@ -22,7 +22,7 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
     /* for recursive substitution */
     @NotNull
     public IExpr substitute(@NotNull IExpr body) {
-        return body.visit(new SubstituteVisitor(exprFactory, primitives, assignments)).result;
+        return substitute(exprFactory, primitives, assignments, body);
     }
 
     @Override
@@ -32,7 +32,7 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
 
     @NotNull
     public IExpr substitute(@NotNull Assignments assignments, @NotNull IExpr body) {
-        return body.visit(new SubstituteVisitor(exprFactory, primitives, assignments)).result;
+        return substitute(exprFactory, primitives, assignments, body);
     }
 
     @Override
@@ -41,7 +41,9 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
     }
 
     /* convenience function */
-    public static @NotNull IExpr substitute(@NotNull ExprFactory exprFactory, @NotNull Primitives primitives, @NotNull IEvaluator<HonsValue> evaluator, @NotNull Assignments assignments, @NotNull IExpr body) {
+    public static @NotNull IExpr substitute(@NotNull ExprFactory exprFactory, @NotNull Primitives primitives, @NotNull Assignments assignments, @NotNull IExpr body) {
+        if (assignments.getAssignmentsAsMap().isEmpty())
+            return body;
         return body.visit(new SubstituteVisitor(exprFactory, primitives, assignments)).result;
     }
 

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/SubstituteVisitor.java
@@ -8,21 +8,43 @@ import java.util.Optional;
 
 /* since this recurses into itself, I suppose we can just reuse result, instead of creating lots of new visitors */
 class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
+    public static class TakePut<T> {
+        private T value;
+        public TakePut() {
+            this.value = null;
+        }
+        public void put(T value) {
+            assert this.value == null;
+            assert value != null;
+            this.value = value;
+        }
+        public T take() {
+            assert this.value != null;
+            var rv = this.value;
+            this.value = null;
+            return rv;
+        }
+    }
+    
     private final @NotNull ExprFactory exprFactory;
     private final @NotNull Primitives primitives;
     private final @NotNull Assignments assignments;
-    IExpr result;
+    private final @NotNull TakePut<IExpr> result;
 
     public SubstituteVisitor(@NotNull ExprFactory exprFactory, @NotNull Primitives primitives, @NotNull Assignments assignments) {
         this.exprFactory = exprFactory;
         this.primitives = primitives;
         this.assignments = assignments;
+        this.result = new TakePut<>();
     }
 
     /* for recursive substitution */
     @NotNull
     public IExpr substitute(@NotNull IExpr body) {
-        return substitute(exprFactory, primitives, assignments, body);
+        if (assignments.getAssignmentsAsMap().isEmpty())
+            return body;
+        body.visit(this);
+        return result.take();
     }
 
     @Override
@@ -44,7 +66,7 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
     public static @NotNull IExpr substitute(@NotNull ExprFactory exprFactory, @NotNull Primitives primitives, @NotNull Assignments assignments, @NotNull IExpr body) {
         if (assignments.getAssignmentsAsMap().isEmpty())
             return body;
-        return body.visit(new SubstituteVisitor(exprFactory, primitives, assignments)).result;
+        return new SubstituteVisitor(exprFactory, primitives, assignments).substitute(body);
     }
 
     @Override
@@ -54,13 +76,13 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
 
     @Override
     public void visitSimple(ISimpleExpr simpleExpr) {
-        result = simpleExpr;
+        result.put(simpleExpr);
     }
 
     @Override
     public void visitSymbol(ISymbolExpr symbolExpr) {
         var assignedValue = assignments.get(symbolExpr.getValue());
-        result = assignedValue == null ? symbolExpr : exprFactory.wrap(assignedValue);
+        result.put(assignedValue == null ? symbolExpr : exprFactory.wrap(assignedValue));
     }
 
     @Override
@@ -73,7 +95,7 @@ class SubstituteVisitor implements IExprVisitor, ISubstitutor<HonsValue> {
                 .map(val -> exprFactory.cons(consExpr.fst(), exprFactory.wrap(val)));
         }
         
-        result = rv.orElseGet(() -> visitApply(consExpr));
+        result.put(rv.orElseGet(() -> visitApply(consExpr)));
     }
 
     public @NotNull IConsExpr visitApply(@NotNull IConsExpr consExpr) {

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
@@ -2,6 +2,7 @@ package uk.bs338.hashLisp.jproto.eval.expr;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import uk.bs338.hashLisp.jproto.ConsPair;
 import uk.bs338.hashLisp.jproto.eval.Tag;
 import uk.bs338.hashLisp.jproto.hons.HonsHeap;
 import uk.bs338.hashLisp.jproto.hons.HonsValue;
@@ -177,17 +178,19 @@ public class ExprFactory {
     
     /* XXX how is this different from ConsPair?! */
     public class ConsExpr extends ExprBase implements IConsExpr {
-        private final @NotNull IExpr fst;
-        private final @NotNull IExpr snd;
+        private final ConsPair<HonsValue> uncons;
+        private IExpr fst;
+        private IExpr snd;
 
         private ConsExpr(@NotNull HonsValue value) {
             super(value);
             assert value.isConsRef();
             /* We can't do this because ExprBase doesn't implement IValue and ConsPair is strict */
 //            var uncons = heap.uncons(value).<ExprBase>fmap(ExprFactory.this::of);
-            var uncons = heap.uncons(value);
-            fst = wrap(uncons.fst());
-            snd = wrap(uncons.snd());
+            uncons = heap.uncons(value);
+            /* Be lazy about further wrapping */
+            fst = null;
+            snd = null;
         }
 
         @Override public boolean isCons() {
@@ -201,11 +204,15 @@ public class ExprFactory {
 
         @Override
         public @NotNull IExpr fst() {
+            if (fst == null)
+                fst = wrap(uncons.fst());
             return fst;
         }
 
         @Override
         public @NotNull IExpr snd() {
+            if (snd == null)
+                snd = wrap(uncons.snd());
             return snd;
         }
 

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
@@ -126,7 +126,7 @@ public class ExprFactory {
             return true;
         }
 
-        @Override public <V extends IExprVisitor2> @NotNull V visit(@NotNull V visitor) {
+        @Override public <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor) {
             visitor.visitSimple(this);
             return visitor;
         }
@@ -142,7 +142,7 @@ public class ExprFactory {
             return true;
         }
 
-        @Override public <V extends IExprVisitor2> @NotNull V visit(@NotNull V visitor) {
+        @Override public <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor) {
             visitor.visitSymbol(this);
             return visitor;
         }
@@ -194,7 +194,7 @@ public class ExprFactory {
             return true;
         }
 
-        @Override public <V extends IExprVisitor2> @NotNull V visit(@NotNull V visitor) {
+        @Override public <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor) {
             visitor.visitCons(this);
             return visitor;
         }

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactory.java
@@ -7,7 +7,6 @@ import uk.bs338.hashLisp.jproto.ConsPair;
 import uk.bs338.hashLisp.jproto.eval.Tag;
 import uk.bs338.hashLisp.jproto.hons.HonsHeap;
 import uk.bs338.hashLisp.jproto.hons.HonsValue;
-import uk.bs338.hashLisp.jproto.wrapped.IWrappedValue;
 
 import java.util.EnumMap;
 import java.util.Objects;

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IConsExpr.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IConsExpr.java
@@ -12,15 +12,12 @@ public interface IConsExpr extends IExpr {
     
     void setMemoEval(IExpr expr);
     
-    /* XXX: not sure this is needed, nor correct? */
     /* normal form means: something that could be applied because it is fully evaluated
      * if the head is not a * symbol, then we could call eval and have it try to apply
      */
     @Override
     default boolean isNormalForm() {
         return fst().isSymbol() && fst().asSymbolExpr().isDataHead();
-//        return fst().isSymbol() && fst().asSymbolExpr().symbolNameAsString().startsWith("*");
-//        return fst().isSymbol() && fst().asSymbolExpr().symbolName().fst().toSmallInt() == '*'; // XXX
     }
 
     @Override

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExpr.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExpr.java
@@ -23,7 +23,7 @@ public interface IExpr {
     }
 
     @Contract("_->param1")
-    <V extends IExprVisitor2> @NotNull V visit(@NotNull V visitor);
+    <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor);
 
     boolean isNormalForm();
     boolean isHeadNormalForm();

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExpr.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExpr.java
@@ -3,13 +3,16 @@ package uk.bs338.hashLisp.jproto.eval.expr;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import uk.bs338.hashLisp.jproto.eval.Tag;
+import uk.bs338.hashLisp.jproto.hons.HonsHeap;
 import uk.bs338.hashLisp.jproto.hons.HonsValue;
 
 import java.util.NoSuchElementException;
 
 public interface IExpr {
     HonsValue getValue();
+    default HonsHeap getHeap() { throw new NoSuchElementException(); }
 
+    /* XXX: use enum instead of isSimple+isSymbol+isCons as a only-one-may-be-true */
     default boolean isSimple() {
         return false;
     }
@@ -50,4 +53,42 @@ public interface IExpr {
     }
 
     @NotNull String valueToString();
+
+    IExpr nil = new ISimpleExpr() {
+        @Override
+        public HonsValue getValue() {
+            return HonsValue.nil;
+        }
+
+        @Override
+        public <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor) {
+            visitor.visitSimple(this);
+            return visitor;
+        }
+
+        @Override
+        public @NotNull String valueToString() {
+            return HonsValue.nil.toString();
+        }
+    };
+    
+    static IExpr ofSmallInt(int num) {
+        return new ISimpleExpr() {
+            @Override
+            public HonsValue getValue() {
+                return HonsValue.fromSmallInt(num);
+            }
+
+            @Override
+            public <V extends IExprVisitor> @NotNull V visit(@NotNull V visitor) {
+                visitor.visitSimple(this);
+                return visitor;
+            }
+
+            @Override
+            public @NotNull String valueToString() {
+                return getValue().toString();
+            }
+        };
+    }
 }

--- a/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExprVisitor.java
+++ b/jproto/src/main/java/uk/bs338/hashLisp/jproto/eval/expr/IExprVisitor.java
@@ -1,6 +1,6 @@
 package uk.bs338.hashLisp.jproto.eval.expr;
 
-public interface IExprVisitor2 {
+public interface IExprVisitor {
     void visitSimple(ISimpleExpr simpleExpr);
 
     default void visitSymbol(ISymbolExpr symbolExpr) {

--- a/jproto/src/test/java/uk/bs338/hashLisp/jproto/LispExamplesTest.java
+++ b/jproto/src/test/java/uk/bs338/hashLisp/jproto/LispExamplesTest.java
@@ -75,4 +75,18 @@ public class LispExamplesTest {
             "((lambda (Y fib$) ((Y fib$) 5)) (lambda (f) ((lambda (x) (f (x x))) (lambda (x) (f (x x))))) (lambda (fib$$) (lambda (n) (zerop n 1 (mul n (fib$$ (add n -1)))))))"
         );
     }
+    
+    @Test void nameCaptureProblem() {
+        assertEval(
+            "(*data y z)",
+            "(((lambda (x) (lambda (y) (data x y))) y) z)"
+        );
+    }
+    
+    @Test void nameCaptureProblemDeeper() {
+        assertEval(
+            "(*data (*data y y) z)",
+            "(((lambda (x) (lambda (y) (data x y))) (data y y)) z))"
+        );
+    }
 }

--- a/jproto/src/test/java/uk/bs338/hashLisp/jproto/LispExamplesTest.java
+++ b/jproto/src/test/java/uk/bs338/hashLisp/jproto/LispExamplesTest.java
@@ -1,8 +1,9 @@
-package uk.bs338.hashLisp.jproto.eval;
+package uk.bs338.hashLisp.jproto;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
 import uk.bs338.hashLisp.jproto.driver.MemoEvalChecker;
+import uk.bs338.hashLisp.jproto.eval.LazyEvaluator;
 import uk.bs338.hashLisp.jproto.hons.HonsHeap;
 import uk.bs338.hashLisp.jproto.reader.CharClassifier;
 import uk.bs338.hashLisp.jproto.reader.Reader;

--- a/jproto/src/test/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactoryTest.java
+++ b/jproto/src/test/java/uk/bs338/hashLisp/jproto/eval/expr/ExprFactoryTest.java
@@ -140,7 +140,7 @@ class ExprFactoryTest {
     
     @Nested
     class Visitor {
-        class MockVisitor implements IExprVisitor2 {
+        class MockVisitor implements IExprVisitor {
             String type;
             IExpr expr;
             


### PR DESCRIPTION
* Refactor ArgSpec & SubstituteVisitor
* Identify and resolve name capture problem.
* IExpr.nil & IExpr.ofSmallInt values
* ExprFactory: lazier wrapping of ConsExpr (benchmark: 15070 loops/sec)
* Rename IExprVisitor2 and move LispExamplesTest